### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos9_sflow.j2
+++ b/templates/dellos9_sflow.j2
@@ -28,7 +28,7 @@ dellos_sflow:
 {% if dellos_sflow is defined and dellos_sflow %}
 
 {% if dellos_sflow %}
-{% for key,value in dellos_sflow.iteritems() %}
+{% for key,value in dellos_sflow.items() %}
   {% if key == "sflow_enable" %}
     {% if value %}
 sflow enable


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs